### PR TITLE
nbft: Fix struct nbft_info_discovery annotation

### DIFF
--- a/src/nvme/nbft.h
+++ b/src/nvme/nbft.h
@@ -1099,7 +1099,7 @@ struct nbft_info_hfi {
 };
 
 /**
- * nbft_info_discovery - Discovery Descriptor
+ * struct nbft_info_discovery - Discovery Descriptor
  * @index:    The number of this Discovery Descriptor in the Discovery
  * 	      Descriptor List.
  * @security: The Security Profile Descriptor, see &struct nbft_info_security.


### PR DESCRIPTION
kernel-doc-check complaining about wrong doc annotation:

  nbft.h:1113: warning: cannot understand function prototype: 'struct nbft_info_discovery '